### PR TITLE
Use sider.ini for setting `memory_limit`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,5 @@ RUN phpenv install ${PHP_VERSION} && phpenv global ${PHP_VERSION}
 RUN apt-get install -y php-pear
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY sider.ini /root/.phpenv/versions/${PHP_VERSION}/etc/conf.d/sider.ini

--- a/sider.ini
+++ b/sider.ini
@@ -1,0 +1,4 @@
+[PHP]
+; Maximum amount of memory a script may consume (128MB)
+; http://php.net/memory-limit
+memory_limit = -1


### PR DESCRIPTION
`memory_limit` of `php.ini` limits 128MB by [default](http://php.net/manual/en/ini.core.php#ini.memory-limit). In Sider, It has become
PHP_CodeSniffer's analysis error because of memory shortage.
So, prepare `php.ini` beforehand and COPY it into containers.

See also https://github.com/sider/runner_code_sniffer/pull/45

What do you think?